### PR TITLE
 Fix double HTTP host header

### DIFF
--- a/lib/py/src/transport/THttpClient.py
+++ b/lib/py/src/transport/THttpClient.py
@@ -120,7 +120,7 @@ class THttpClient(TTransportBase):
     self.__wbuf = BytesIO()
 
     # HTTP request
-    self.__http.putrequest('POST', self.path)
+    self.__http.putrequest('POST', self.path, skip_host = True)
 
     # Write headers
     self.__http.putheader('Host', self.host)


### PR DESCRIPTION
HTTPConnection.putrequest has a skip_host flag that is false by default. When false, the host is automatically added to the HTTP header. The host is also added manually so there is currently two occurrences in the header. This may cause issues depending on how the receiver handles recurring headers.

This change simply sets the skip_host flag to true.